### PR TITLE
Resolves #2 Adds a jqLite-friendly version of the .on() wrapper

### DIFF
--- a/public/js/types/jquery/jquery.d.ts
+++ b/public/js/types/jquery/jquery.d.ts
@@ -616,6 +616,7 @@ interface JQuery {
 
     on(events: string, selector?: string, data?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
     on(events: string, selector?: string, handler?: (eventObject: JQueryEventObject) => any): JQuery;
+    on(events: string, handler?: (eventObject: JQueryEventObject) => any): JQuery;
     on(eventsMap: { [key: string]: any; }, selector?: any, data?: any): JQuery;
 
     one(events: string, selector?: any, data?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;


### PR DESCRIPTION
New version does not require the optional selector attribute and thus complies to jqLite's signature
